### PR TITLE
Moving to internal YCMB version for elasticsearch support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rijalati/alpine-zulu-jdk8:latest-mini
+FROM bmedora/alpine-zulu-jdk8:latest-mini
 MAINTAINER engops@bluemedora.com
 
 ENV YCSB_VERSION=0.17.0-SNAPSHOT \

--- a/Dockerfile.localfile
+++ b/Dockerfile.localfile
@@ -1,13 +1,19 @@
+FROM alpine:latest AS builder
+
+
+COPY ycsb-0.17.0-SNAPSHOT.tar.gz /
+RUN cd /opt \
+  && tar -xzvf /ycsb-0.17.0-SNAPSHOT.tar.gz 
+
 FROM rijalati/alpine-zulu-jdk8:latest-mini
-MAINTAINER engops@bluemedora.com
+MAINTAINER ritchie@selectstar.io
 
 ENV YCSB_VERSION=0.17.0-SNAPSHOT \
     PATH=${PATH}:/usr/bin
 
-RUN apk --update --no-cache add python mksh \
-    && cd /opt \
-    && eval curl "-Ls https://github.com/BlueMedoraPublic/YCSB/archive/${YCSB_VERSION}.tar.gz" \
-    | tar -xzvf -
+COPY --from=builder /opt/ /opt/
+
+RUN apk --update --no-cache add python mksh
 
 COPY start.sh /start.sh
 RUN chmod +x /start.sh

--- a/Dockerfile.localfile
+++ b/Dockerfile.localfile
@@ -5,7 +5,7 @@ COPY ycsb-0.17.0-SNAPSHOT.tar.gz /
 RUN cd /opt \
   && tar -xzvf /ycsb-0.17.0-SNAPSHOT.tar.gz 
 
-FROM rijalati/alpine-zulu-jdk8:latest-mini
+FROM bmedora/alpine-zulu-jdk8:latest-mini
 MAINTAINER engops@bluemedora.com
 
 ENV YCSB_VERSION=0.17.0-SNAPSHOT \

--- a/Dockerfile.localfile
+++ b/Dockerfile.localfile
@@ -6,7 +6,7 @@ RUN cd /opt \
   && tar -xzvf /ycsb-0.17.0-SNAPSHOT.tar.gz 
 
 FROM rijalati/alpine-zulu-jdk8:latest-mini
-MAINTAINER ritchie@selectstar.io
+MAINTAINER engops@bluemedora.com
 
 ENV YCSB_VERSION=0.17.0-SNAPSHOT \
     PATH=${PATH}:/usr/bin


### PR DESCRIPTION
Needed the latest YCSB in order to benchmark Elasticsearch.  The only way to compile was to disable a few of the database backends that did not compile cleanly (for which we aren't using).  